### PR TITLE
Removed logging

### DIFF
--- a/geocoder.go
+++ b/geocoder.go
@@ -4,7 +4,6 @@ package geocoder
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -160,7 +159,6 @@ func Geocoding(address Address) (Location, error) {
 	// Send the HTTP request and get the results
 	results, err := httpRequest(url)
 	if err != nil {
-		log.Println(err)
 		return location, err
 	}
 
@@ -240,7 +238,6 @@ func GeocodingReverse(location Location) ([]Address, error) {
 	// Send the HTTP request and get the results
 	results, err := httpRequest(url)
 	if err != nil {
-		log.Println(err)
 		return addresses, err
 	}
 
@@ -259,7 +256,6 @@ func GeocodingReverseIntl(location Location, language string) ([]Address, error)
 	// Send the HTTP request and get the results
 	results, err := httpRequest(url)
 	if err != nil {
-		log.Println(err)
 		return addresses, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kelvins/geocoder
+
+go 1.20


### PR DESCRIPTION
Context
A library should never log to console like this. If logging is needed, a logger should be accepted as an argument. We're getting a lot of "Your request was denied" error from this package.

Changes
- Added a go mod file (needed as of Go v1.17)
- Removed logging

To Do
- N/A